### PR TITLE
docs: require multiple commits when a PR needs new packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ All PRs must be reviewed by a teammate before they are eligle to be merged into 
   * Valid types are `chore:`, `docs:`, `style:`, `refactor:`, `perf:`, and `test:`
 * Do not mix feature changes (added functionality) with fixes (restored functionality), refactors (no change in functionality), or style changes (only whitespace or other cosmetic changes).
 * Before a PR is ready for review, make sure that it is a single commit. If the combined commit is too large or disparate, consider multiple PRs.
+* The exception to the above single commit rule is when a PR introduces new packages. Create one extra commit in the same PR for each new package your PR needs.
 * Do not modify a project's `.gitignore` to add files related to your editor or environment. Use your own [global .gitignore](https://stackoverflow.com/questions/7335420/global-git-ignore/22885996#22885996) for that instead.
 
 ## Workflow


### PR DESCRIPTION
Added a new bullet point to to require multiple commits when a new package is added.