### PR TITLE
docs: add naming conventions guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,17 @@ Line length should be limited to 80 characters.
   3. Constants and other setup: this includes anything *absolutely necessary* to be defined before `module.exports`
   4. Exports: `module.exports` should be as close to the beginning of the file as possible. The module should export either a single function or a "catalog object", e.g. `module.exports = { method1, method2, ... }`
   5. Functions: these go after the above sections. Use function hoisting to control the placement of your functions so that important, high-level functions are above smaller more-general utility functions.
-* Use descriptive variable names. Function names should be a verb like `route()` or verb combined with a noun like `routeRequest()`.
 * Keep your functions short. If your function is over 40 lines, you should have a good reason.
 * Functions should not accept more than 3 arguments. Use a single options object if you need more arguments.
 * Keep nesting to a minimum. Use [early returns](https://blog.timoxley.com/post/47041269194/avoid-else-return-early), single-line conditionals, and function calls.
+##### Naming Convention
+- Use descriptive variable names. Function names should be a verb like route() or verb combined with a noun like routeRequest().
+- Use meaningful descriptive names, e.g `getUserPosts` instead of `getUserData`.
+- Favor descriptive over concise names, e.g `findUserById` instead of `findUser`.
+- Use consistent names per concept. In a project, function names should be like `getUsers`, `getQuestions` and `getCourses` instead of `getUsers`, `retrieveQuestions` and `returnCourses`.
+- Variable names should be self-descriptive, it shouldn't need a comment for additional documentation.
+- Booleans should have a prefix like is, has, or are to help engineers with identifying booleans easier, e.g `isVisible` instead of `visible`.
+
 
 ## Git & Github
 


### PR DESCRIPTION
Approaches to address vague/inconsistent vocabulary in our projects:
- Set a naming convention implicitly: By bouncing PRs back because of vague names, and discussing a better convention to use per PR with other devs. This should build an understanding of what naming convention we want to use across our projects. The disadvantage of this solution is that we won’t have a reference to refer to, instead, each engineer would suggest a different convention. Also, it won’t be easy for new engineers to get familiar with our naming convention.
- Add new guidelines for naming standards: By setting new standards to fit our needs and apply them on new changes to our projects, the advantage of this approach is having explicit guidelines to stick to and refer to when reviewing/creating new PRs, the disadvantage of this approach is that we will need to figure out what fits our projects the best instead of applying any random naming convention that other teams/companies use. However, guidelines could be adjusted incrementally according to our needs.
- Refer to a predefined/popular naming convention: Applying any popular naming standard will help us having a ready-to-use guide to refer to while making changes in our code, but it might not be the best fit for our projects.

Adding explicit guidelines to work with is the best approach, so that we can have something to refer to when we review PRs or make new changes in the code. It will be also more clear to new developers to know what naming standards they should stick to than figuring it out from implicit standards in PRs’ reviews and team discussions.