### PR TITLE
Add line length exceptions from codeStandards.md

### DIFF
--- a/codeStandards.md
+++ b/codeStandards.md
@@ -6,7 +6,12 @@ Some developers feel the need to debate code style. Other engineers will use the
 
 We use the [JavaScript Standard Style](https://standardjs.com/) in our code. This is the style used by npm, GitHub, Zeit, MongoDB, Express, Electron, and many others. Be sure to use an automatic formatter like [standard-formatter](https://atom.io/packages/standard-formatter) for Atom and [vscode-standardjs](https://marketplace.visualstudio.com/items/chenxsan.vscode-standardjs) for Visual Studio Code.
 
-Line length should be limited to 120 characters.
+Line length should be limited to **120 characters**. 
+Exceptions:
+- Comments after the code do not count in the character count.
+  - A comment after the code are more readable. Putting a comment on the same line signifies that comment only applies to this one line. This way the comment doesn't bloat the actual function.
+- Test case headings can go over 120 character.
+  - It's easier to read test case headings on a single line and they have a tendency to go over the line length.
 
 ### Code Principles
 


### PR DESCRIPTION
This is in regards to @SavvasZaidQuadri's changes and suggestions on his [PR on OUTL-2180](https://github.com/outlier-org/outlier-api/pull/8065/files#diff-d6148af84b2317796e49b9829c36f0eb32153d10a644d78fc06a8037548dbce1)